### PR TITLE
fix scm in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,11 @@
 
 	<url>http://openmrs.org</url>
 
-	<scm>
-		<connection>scm:svn:http://svn.openmrs.org/openmrs-modules/radiology/trunk/</connection>
-		<developerConnection>scm:svn:http://svn.openmrs.org/openmrs-modules/radiology/trunk/</developerConnection>
-		<url>http://svn.openmrs.org/openmrs-modules/radiology/trunk/</url>
-	</scm>
+    <scm>
+        <connection>scm:git:https://github.com/openmrs/openmrs-module-radiologydcm4chee</connection>
+        <developerConnection>scm:git:https://github.com/openmrs/openmrs-module-radiologydcm4chee</developerConnection>
+        <url>https://github.com/openmrs/openmrs-module-radiologydcm4chee</url>
+    </scm>
 
 	<modules>
 		<module>api</module>


### PR DESCRIPTION
modules repository location moved from svn to github,
point <scm> section of root pom.xml to github