### PR TITLE
RAD-54 Study.setup() overrides Study.scheduledStatus

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/Study.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Study.java
@@ -187,9 +187,6 @@ public class Study {
 		if (u.hasRole(Roles.ReadingPhysician, true) && getReadingPhysician() == null)
 			setReadingPhysician(u);
 		
-		if (o.getStartDate() != null)
-			setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
-		
 		if (o.getOrderer() == null)
 			o.setOrderer(u);
 		o.setOrderType(Utils.getRadiologyOrderType().get(0));

--- a/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
@@ -22,6 +22,7 @@ import org.openmrs.module.radiology.DicomUtils;
 import org.openmrs.module.radiology.DicomUtils.OrderRequest;
 import org.openmrs.module.radiology.MwlStatus;
 import org.openmrs.module.radiology.RadiologyService;
+import org.openmrs.module.radiology.ScheduledProcedureStepStatus;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.Utils;
 import org.openmrs.module.radiology.db.GenericDAO;
@@ -69,6 +70,11 @@ public class RadiologyServiceImpl extends BaseOpenmrsService implements Radiolog
 		}
 		
 		Order order = study.order();
+		
+		if (study.getScheduledStatus() == null && order.getStartDate() != null) {
+			study.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+		}
+		
 		try {
 			sdao.saveStudy(study);
 			File file = new File(Utils.mwlDir(), study.getId() + ".xml");


### PR DESCRIPTION
* set Study.scheduledStatus to SCHEDULED if order.startDate
 is selected in RadiologyService only if no other scheduledStatus has been
 chosen

see https://issues.openmrs.org/browse/RAD-54