### PR TITLE
RAD-64 Add RadiologyOrderFormControllerTest

### DIFF
--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -15,44 +15,46 @@
                         http://www.springframework.org/schema/util
                         http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
+	<bean id="radiologyService"
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager">
+			<ref bean="transactionManager" />
+		</property>
+		<property name="target">
+			<bean class="org.openmrs.module.radiology.impl.RadiologyServiceImpl">
+				<property name="gdao">
+					<bean class="org.openmrs.module.radiology.db.hibernate.GenericDAOImpl">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
+
+				<property name="sdao">
+					<bean class="org.openmrs.module.radiology.db.hibernate.StudyDAOImpl">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors" />
+		</property>
+		<property name="transactionAttributeSource">
+			<ref bean="transactionAttributeSource" />
+		</property>
+	</bean>
+
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list>
 				<value>org.openmrs.module.radiology.RadiologyService</value>
-				<bean
-					class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
-					<property name="transactionManager">
-						<ref bean="transactionManager" />
-					</property>
-					<property name="target">
-						<bean class="org.openmrs.module.radiology.impl.RadiologyServiceImpl">
-							<property name="gdao">
-								<bean class="org.openmrs.module.radiology.db.hibernate.GenericDAOImpl">
-									<property name="sessionFactory">
-										<ref bean="sessionFactory" />
-									</property>
-								</bean>
-							</property>
-							<property name="sdao">
-								<bean class="org.openmrs.module.radiology.db.hibernate.StudyDAOImpl">
-									<property name="sessionFactory">
-										<ref bean="sessionFactory" />
-									</property>
-								</bean>
-							</property>
-						</bean>
-					</property>
-					<property name="preInterceptors">
-						<list>
-							<ref bean="authorizationInterceptor" />
-						</list>
-					</property>
-					<property name="transactionAttributeSource">
-						<bean
-							class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource" />
-					</property>
-				</bean>
+				<ref local="radiologyService" />
 			</list>
 		</property>
 	</bean>
+
+
 </beans>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -17,7 +17,7 @@
 	<activator>${project.parent.groupId}.${project.parent.artifactId}.RadiologyActivator
 	</activator>
 
-	<require_version>1.9.4 - 1.9.*</require_version>
+	<require_version>1.9.9</require_version>
 	<require_database_version>1.0.0</require_database_version>
 
 

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -1,0 +1,195 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.test;
+
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
+import org.openmrs.Role;
+import org.openmrs.User;
+import org.openmrs.module.radiology.Modality;
+import org.openmrs.module.radiology.RequestedProcedurePriority;
+import org.openmrs.module.radiology.Roles;
+import org.openmrs.module.radiology.Study;
+
+public class RadiologyTestData {
+	
+	/**
+	 * Convenience method constructing a study order for the tests
+	 */
+	public static Study getMockStudy1PreSave() {
+		
+		Study mockStudy = new Study();
+		mockStudy.setOrderId(getMockRadiologyOrder1().getId());
+		mockStudy.setModality(Modality.CT);
+		mockStudy.setPriority(RequestedProcedurePriority.STAT);
+		
+		return mockStudy;
+	}
+	
+	/**
+	 * Convenience method constructing a study order for the tests
+	 */
+	public static Study getMockStudy1PostSave() {
+		
+		Study mockStudy = getMockStudy1PreSave();
+		
+		int studyId = 1;
+		mockStudy.setId(studyId);
+		mockStudy.setStudyInstanceUid(getStudyPrefix() + studyId);
+		
+		return mockStudy;
+	}
+	
+	/**
+	 * Convenience method to get the StudyPrefix needed for StudyInstanceUid construction in the
+	 * tests
+	 */
+	public static String getStudyPrefix() {
+		
+		return "1.2.826.0.1.3680043.8.2186.1.";
+	}
+	
+	/**
+	 * Convenience method constructing a mock order for the tests
+	 */
+	public static Order getMockRadiologyOrder1() {
+		
+		Order mockOrder = new Order();
+		mockOrder.setOrderId(1);
+		mockOrder.setOrderType(getMockRadiologyOrderType());
+		mockOrder.setPatient(getMockPatient1());
+		Calendar cal = Calendar.getInstance();
+		cal.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
+		mockOrder.setStartDate(cal.getTime());
+		mockOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+		mockOrder.setDiscontinued(false);
+		mockOrder.setVoided(false);
+		
+		return mockOrder;
+	}
+	
+	/**
+	 * Convenience method constructing a mock radiology order type for the tests
+	 */
+	public static OrderType getMockRadiologyOrderType() {
+		
+		return new OrderType("Radiology", "Order for radiology procedures");
+	}
+	
+	/**
+	 * Convenience method constructing a mock patient for the tests
+	 */
+	public static Patient getMockPatient1() {
+		
+		Patient mockPatient = new Patient();
+		mockPatient.setPatientId(1);
+		mockPatient.addIdentifiers(getPatientIdentifiers("100"));
+		mockPatient.setGender("M");
+		
+		Set<PersonName> personNames = new HashSet<PersonName>();
+		PersonName personName = new PersonName();
+		personName.setFamilyName("Doe");
+		personName.setGivenName("John");
+		personName.setMiddleName("Francis");
+		personNames.add(personName);
+		mockPatient.setNames(personNames);
+		
+		Calendar cal = Calendar.getInstance();
+		cal.set(1950, Calendar.APRIL, 1, 0, 0, 0);
+		mockPatient.setBirthdate(cal.getTime());
+		
+		return mockPatient;
+	}
+	
+	/**
+	 * Convenience method constructing PatientIdentifiers
+	 */
+	public static Set<PatientIdentifier> getPatientIdentifiers(String id) {
+		PatientIdentifier patientIdentifier = new PatientIdentifier();
+		patientIdentifier.setIdentifierType(getPatientIdentifierType());
+		patientIdentifier.setIdentifier(id);
+		patientIdentifier.setPreferred(true);
+		Set<PatientIdentifier> patientIdentifiers = new HashSet<PatientIdentifier>();
+		patientIdentifiers.add(patientIdentifier);
+		return patientIdentifiers;
+	}
+	
+	/**
+	 * Convenience method constructing a PatientIdentifierType
+	 */
+	public static PatientIdentifierType getPatientIdentifierType() {
+		PatientIdentifierType patientIdentifierType = new PatientIdentifierType();
+		patientIdentifierType.setPatientIdentifierTypeId(1);
+		patientIdentifierType.setName("Test Identifier Type");
+		patientIdentifierType.setDescription("Test description");
+		
+		return patientIdentifierType;
+	}
+	
+	/**
+	 * Convenience method constructing a mock user with role RADIOLOGY_REFERRING_PHYSICIAN for the
+	 * tests
+	 */
+	public static User getMockRadiologyReferringPhysician() {
+		
+		Role role = new Role(Roles.ReferringPhysician);
+		Set<Role> roles = new HashSet<Role>();
+		roles.add(role);
+		
+		User radiologyReferringPhysician = new User();
+		radiologyReferringPhysician.setRoles(roles);
+		radiologyReferringPhysician.setPerson(getMockUserPerson());
+		
+		return radiologyReferringPhysician;
+	}
+	
+	/**
+	 * Convenience method constructing a mock person for the tests
+	 */
+	public static Person getMockUserPerson() {
+		
+		PersonName name = new PersonName();
+		name.setFamilyName("Karlsson");
+		name.setGivenName("Karl");
+		Set<PersonName> names = new HashSet<PersonName>();
+		names.add(name);
+		
+		Person person = new Person();
+		person.setNames(names);
+		
+		return person;
+	}
+	
+	/**
+	 * Convenience method constructing a mock user with role RADIOLOGY_SCHEDULER for the tests
+	 */
+	public static User getMockRadiologyScheduler() {
+		
+		Role role = new Role(Roles.Scheduler);
+		Set<Role> roles = new HashSet<Role>();
+		roles.add(role);
+		
+		User radiologyScheduler = new User();
+		radiologyScheduler.setRoles(roles);
+		radiologyScheduler.setPerson(getMockUserPerson());
+		
+		return radiologyScheduler;
+	}
+	
+}

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
@@ -1,0 +1,539 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.web.controller;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.openmrs.Concept;
+import org.openmrs.Order;
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.PatientService;
+import org.openmrs.module.radiology.MwlStatus;
+import org.openmrs.module.radiology.PerformedProcedureStepStatus;
+import org.openmrs.module.radiology.RadiologyService;
+import org.openmrs.module.radiology.Study;
+import org.openmrs.module.radiology.Utils;
+import org.openmrs.module.radiology.test.RadiologyTestData;
+import org.openmrs.test.BaseContextMockTest;
+import org.openmrs.test.Verifies;
+import org.openmrs.web.WebConstants;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Tests {@link RadiologyOrderFormController}
+ */
+public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
+	
+	@Mock
+	private PatientService patientService;
+	
+	@Mock
+	private OrderService orderService;
+	
+	@Mock
+	private RadiologyService radiologyService;
+	
+	@Mock
+	private ConceptService conceptService;
+	
+	@Mock
+	private AdministrationService administrationService;
+	
+	@InjectMocks
+	private RadiologyOrderFormController radiologyOrderFormController = new RadiologyOrderFormController();
+	
+	/**
+	 * @see RadiologyOrderFormController#get(Integer, Integer)
+	 */
+	@Test
+	@Verifies(value = "should populate model and view with new order and study when given empty request parameters", method = "get(Integer, Integer)")
+	public void get_shouldPopulateModelAndViewWithNewOrderAndStudyWhenGivenEmptyRequestParameters() throws Exception {
+		
+		ModelAndView modelAndView = radiologyOrderFormController.get(null, null);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("study"));
+		Study study = (Study) modelAndView.getModelMap().get("study");
+		assertThat(study.getId(), is(0));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("order"));
+		Order order = (Order) modelAndView.getModelMap().get("order");
+		assertNull(order.getOrderId());
+		
+		assertNull(order.getOrderer());
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#get(Integer, Integer)
+	 */
+	@Test
+	@Verifies(value = "should populate model and view with new order and study with prefilled orderer when given empty request parameters by referring physician", method = "get(Integer, Integer)")
+	public void get_shouldPopulateModelAndViewWithNewOrderAndStudyWithPrefilledOrdererWhenGivenEmptyRequestParametersByReferringPhysician()
+	        throws Exception {
+		
+		//given
+		User mockReferringPhysician = RadiologyTestData.getMockRadiologyReferringPhysician();
+		when(userContext.getAuthenticatedUser()).thenReturn(mockReferringPhysician);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.get(null, null);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("study"));
+		Study study = (Study) modelAndView.getModelMap().get("study");
+		assertThat(study.getId(), is(0));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("order"));
+		Order order = (Order) modelAndView.getModelMap().get("order");
+		assertNull(order.getOrderId());
+		
+		assertNotNull(order.getOrderer());
+		assertThat(order.getOrderer(), is(mockReferringPhysician));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#get(Integer, Integer)
+	 */
+	@Test
+	@Verifies(value = "should populate model and view with new order and study with prefilled patient when given patient id", method = "get(Integer, Integer)")
+	public void get_shouldPopulateModelAndViewWithNewOrderAndStudyWithPrefilledPatientWhenGivenPatientId() throws Exception {
+		
+		//given
+		Patient mockPatient = RadiologyTestData.getMockPatient1();
+		when(patientService.getPatient(mockPatient.getPatientId())).thenReturn(mockPatient);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.get(null, mockPatient.getPatientId());
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("study"));
+		Study study = (Study) modelAndView.getModelMap().get("study");
+		assertThat(study.getId(), is(0));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("order"));
+		Order order = (Order) modelAndView.getModelMap().get("order");
+		assertNull(order.getOrderId());
+		
+		assertNotNull(order.getPatient());
+		assertThat(order.getPatient(), is(mockPatient));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("patientId"));
+		Integer patientId = (Integer) modelAndView.getModelMap().get("patientId");
+		assertThat(patientId, is(mockPatient.getPatientId()));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#get(Integer, Integer)
+	 */
+	@Test
+	@Verifies(value = "should populate model and view with existing order and study when given order id", method = "get(Integer, Integer)")
+	public void get_shouldPopulateModelAndViewWithExistingOrderAndStudyWhenGivenOrderId() throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudy = RadiologyTestData.getMockStudy1PostSave();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudy);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.get(mockOrder.getOrderId(), null);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("study"));
+		Study study = (Study) modelAndView.getModelMap().get("study");
+		assertThat(study, is(mockStudy));
+		
+		assertTrue(modelAndView.getModelMap().containsKey("order"));
+		Order order = (Order) modelAndView.getModelMap().get("order");
+		assertThat(order, is(mockOrder));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to order saved and redirect to radiology order list when save study was successful", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToRadiologyOrderListWhenSaveStudyWasSuccessful()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("saveOrder", "saveOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), null,
+		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.list"));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to order saved and redirect to patient dashboard when save study was successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToPatientDashboardWhenSaveStudyWasSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("saveOrder", "saveOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to saved fail worklist and redirect to patient dashboard when save study was not successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToSavedFailWorklistAndRedirectToPatientDashboardWhenSaveStudyWasNotSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_ERR);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("saveOrder", "saveOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("radiology.savedFailWorklist"));
+		
+		mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("saveOrder", "saveOrder");
+		mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		mockStudyPostSave.setMwlStatus(MwlStatus.UPDATE_ERR);
+		modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("radiology.savedFailWorklist"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to study performed when study performed status is in progress and scheduler is empty and request was issued by radiology scheduler", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToStudyPerformedWhenStudyPerformedStatusIsInProgressAndSchedulerIsEmptyAndRequestWasIssuedByRadiologyScheduler()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		mockStudyPreSave.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		Concept mockConcept = new Concept();
+		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("saveOrder", "saveOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR), is("radiology.studyPerformed"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to voided successfully and redirect to patient dashboard when void order was successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToVoidedSuccessfullyAndRedirectToPatientDashboardWhenVoidOrderWasSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.VOID_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("voidOrder", "voidOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.voidedSuccessfully"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to unvoided successfully and redirect to patient dashboard when unvoid order was successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToUnvoidedSuccessfullyAndRedirectToPatientDashboardWhenUnvoidOrderWasSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.UNVOID_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("unvoidOrder", "unvoidOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.unvoidedSuccessfully"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to discontinued successfully and redirect to patient dashboard when discontinue order was successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToDiscontinuedSuccessfullyAndRedirectToPatientDashboardWhenDiscontinueOrderWasSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.DISCONTINUE_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("discontinueOrder", "discontinueOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.discontinuedSuccessfully"));
+	}
+	
+	/**
+	 * @see RadiologyOrderFormController#post(Integer, Integer, Study, BindingResult, Order,
+	 *      BindingResult)
+	 */
+	@Test
+	@Verifies(value = "should set http session attribute openmrs message to undiscontinued successfully and redirect to patient dashboard when undiscontinue order was successful and given patient id", method = "post(Integer, Integer, Study, BindingResult, Order, BindingResult)")
+	public void post_shouldSetHttpSessionAttributeOpenmrsMessageToUndiscontinueSuccessfullyAndRedirectToPatientDashboardWhenUndiscontinueOrderWasSuccessfulAndGivenPatientId()
+	        throws Exception {
+		
+		//given
+		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
+		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
+		mockStudyPostSave.setMwlStatus(MwlStatus.UNDISCONTINUE_OK);
+		Concept mockConcept = new Concept();
+		
+		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
+		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
+		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(conceptService.getConcept(1)).thenReturn(mockConcept);
+		when(Utils.getRadiologyOrderType()).thenReturn(Arrays.asList(RadiologyTestData.getMockRadiologyOrderType()));
+		when(Utils.studyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addParameter("undiscontinueOrder", "undiscontinueOrder");
+		MockHttpSession mockSession = new MockHttpSession();
+		mockRequest.setSession(mockSession);
+		
+		BindingResult studyErrors = mock(BindingResult.class);
+		when(studyErrors.hasErrors()).thenReturn(false);
+		BindingResult orderErrors = mock(BindingResult.class);
+		when(orderErrors.hasErrors()).thenReturn(false);
+		
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockStudyPreSave.getId(), mockOrder
+		        .getPatient().getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		
+		assertNotNull(modelAndView);
+		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
+		        + mockOrder.getPatient().getPatientId()));
+		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.undiscontinuedSuccessfully"));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>1.9.4</openMRSVersion>
+		<openMRSVersion>1.9.9</openMRSVersion>
 	</properties>
 
 	<build>


### PR DESCRIPTION
* update openmrs-core dependency to 1.9.9 to be able to use Mockito @Mock in Tests
* add RadiologyOrderFormControllerTest using Mockito @Mock
* adapt moduleApplicationContext so that @Autowired in omod finds the
  RadiologyService bean (adds logging advice via openmrs-core
  serviceInterceptors)
* add needed services as members to RadiologyOrderFormController and
 wire via @Autowired

see https://issues.openmrs.org/browse/RAD-64