### PR TITLE
RAD-41 Change default DICOM web viewer to weasis

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/Utils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Utils.java
@@ -90,16 +90,22 @@ public class Utils {
 		return as.getGlobalProperty("radiology.serversHL7Port");
 	}
 	
-	public static String oviyamLocalServerName() {
-		String serverName = as.getGlobalProperty("radiology.oviyamLocalServerName");
+	public static String dicomViewerLocalServerName() {
+		String serverName = as.getGlobalProperty("radiology.dicomViewerLocalServerName");
 		if (serverName == null)
 			return "";
 		else
-			return "serverName=" + as.getGlobalProperty("radiology.oviyamLocalServerName") + "&";
+			return "serverName=" + as.getGlobalProperty("radiology.dicomViewerLocalServerName") + "&";
 	}
 	
-	public static String viewerURLPath() {
-		return as.getGlobalProperty("radiology.viewerURLPath");
+	public static String dicomViewerUrlBase() {
+		return as.getGlobalProperty("radiology.dicomViewerUrlBase");
+	}
+	
+	public static String dicomViewerUrl() {
+		String dicomViewerUrl = Utils.serversAddress() + ":" + Utils.serversPort() + Utils.dicomViewerUrlBase()
+		        + Utils.dicomViewerLocalServerName();
+		return dicomViewerUrl;
 	}
 	
 	static RadiologyService radiologyService() {

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardObsController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardObsController.java
@@ -96,13 +96,12 @@ public class RadiologyDashboardObsController {
 		mav.addObject("obs", obs);
 		mav.addObject("studyUID", study.isCompleted() ? study.getStudyInstanceUid() : null);
 		if (study.isCompleted()) {
-			//    System.out.println("Study UID:"+study.getUid()+" Completed : "+study.isCompleted()+" Patient ID : "+or.getOrder(orderId).getPatient().getId()+" Server : "+Utils.oviyamLocalServerName() );                    
 			String patID = or.getOrder(orderId).getPatient().getPatientIdentifier().getIdentifier();
-			String link = Utils.serversAddress() + ":" + Utils.serversPort() + Utils.viewerURLPath()
-			        + Utils.oviyamLocalServerName() + "studyUID=" + study.getStudyInstanceUid() + "&patientID=" + patID;
-			mav.addObject("oviyamLink", link);
+			String dicomViewerUrl = Utils.dicomViewerUrl() + "studyUID=" + study.getStudyInstanceUid() + "&patientID="
+			        + patID;
+			mav.addObject("dicomViewerUrl", dicomViewerUrl);
 		} else
-			mav.addObject("oviyamLink", null);
+			mav.addObject("dicomViewerUrl", null);
 		mav.addObject("prevs", prevs);
 		mav.addObject("prevsSize", prevs.size());
 		mav.addObject("personName", or.getOrder(orderId).getPatient().getPersonName().getFullName());

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyObsFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyObsFormController.java
@@ -98,7 +98,7 @@ public class RadiologyObsFormController {
 	 * @return model and view populated with observations matching the given criteria
 	 * @should populate model and view with new obs given valid order
 	 * @should populate model and view with obs for given obs and given valid order
-	 * @should populate model and view with oviyamlink for completed study and obs for given obs and
+	 * @should populate model and view with dicom viewer url for completed study and obs for given obs and
 	 *         given valid order
 	 */
 	@RequestMapping(value = "/module/radiology/radiologyObs.form", method = RequestMethod.GET)
@@ -126,13 +126,12 @@ public class RadiologyObsFormController {
 		mav.addObject("obs", obs);
 		mav.addObject("studyUID", study.isCompleted() ? study.getStudyInstanceUid() : null);
 		if (study.isCompleted()) {
-			//    System.out.println("Study UID:"+study.getUid()+" Completed : "+study.isCompleted()+" Patient ID : "+or.getOrder(orderId).getPatient().getId()+" Server : "+Utils.oviyamLocalServerName() );                    
 			String patID = orderService.getOrder(orderId).getPatient().getPatientIdentifier().getIdentifier();
-			String link = Utils.serversAddress() + ":" + Utils.serversPort() + Utils.viewerURLPath()
-			        + Utils.oviyamLocalServerName() + "studyUID=" + study.getStudyInstanceUid() + "&patientID=" + patID;
-			mav.addObject("oviyamLink", link);
+			String dicomViewerUrl = Utils.dicomViewerUrl() + "studyUID=" + study.getStudyInstanceUid() + "&patientID="
+			        + patID;
+			mav.addObject("dicomViewerUrl", dicomViewerUrl);
 		} else
-			mav.addObject("oviyamLink", null);
+			mav.addObject("dicomViewerUrl", null);
 		mav.addObject("prevs", previousObservations);
 		mav.addObject("prevsSize", previousObservations.size());
 	}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -29,7 +29,8 @@
 
 	<extension>
 		<point>org.openmrs.patientDashboardTab</point>
-		<class>@MODULE_PACKAGE@.web.extension.html.RadiologyDashboardExt</class>
+		<class>@MODULE_PACKAGE@.web.extension.html.RadiologyDashboardExt
+		</class>
 	</extension>
 
 	<!-- /Extensions -->
@@ -59,14 +60,6 @@
 		<description>IP address of the dcm4chee</description>
 	</globalProperty>
 	<globalProperty>
-		<property>@MODULE_ID@.viewerURLPath</property>
-		<defaultValue>/oviyam2/viewer.html?</defaultValue>
-		<description>URL for Oviyam/Weasis. Default value for Oviyam
-			:"/oviyam2/viewer.html?". For Weasis(needs Java Web Start) :
-			"/weasis-pacs-connector/viewer.jnlp?"
-		</description>
-	</globalProperty>
-	<globalProperty>
 		<property>@MODULE_ID@.serversPort</property>
 		<defaultValue>8081</defaultValue>
 		<description>Port of the dcm4chee Web</description>
@@ -91,11 +84,24 @@
 		</description>
 	</globalProperty>
 	<globalProperty>
-		<property>@MODULE_ID@.oviyamLocalServerName</property>
-		<defaultValue>oviyamlocal</defaultValue>
-		<description>Local Server name needed for deploying Oviyam. Must match
-			the local server name created in the Oviyam UI. Leave empty for
-			weasis.
+		<property>@MODULE_ID@.dicomViewerUrlBase</property>
+		<defaultValue>/weasis-pacs-connector/viewer?</defaultValue>
+		<description>Base URL for DICOM viewer (e.g. Weasis, Oviyam, ...).
+			Default is for Weasis using weasis-pacs-connector (Weasis needs java
+			on client):
+			"/weasis-pacs-connector/viewer?". For
+			Oviyam:
+			"/oviyam2/viewer.html?".
+		</description>
+	</globalProperty>
+	<globalProperty>
+		<property>@MODULE_ID@.dicomViewerLocalServerName</property>
+		<defaultValue></defaultValue>
+		<description>Local server name needed for deploying Oviyam (default
+			value: "oviyamlocal"). Must match
+			the local server name created in the
+			Oviyam UI. Leave empty for
+			Weasis.
 		</description>
 	</globalProperty>
 	<globalProperty>

--- a/omod/src/main/webapp/portlets/DashboardObsForm.jsp
+++ b/omod/src/main/webapp/portlets/DashboardObsForm.jsp
@@ -15,7 +15,7 @@
 			<tr>
 				<th><spring:message code="radiology.studyResults" /></th>
 				<%--<td><a href="/openmrs/moduleServlet/radiology/viewer.jnlp?studyUID=${studyUID}"><spring:message code="general.download" /></a></td>--%>
-				<td>: <a href="${oviyamLink}" target="_tab">View Study</a></td>
+				<td>: <a href="${dicomViewerUrl}" target="_tab">View Study</a></td>
 			</tr>
 		</c:if>
 	</table>

--- a/omod/src/main/webapp/radiologyObsForm.jsp
+++ b/omod/src/main/webapp/radiologyObsForm.jsp
@@ -581,7 +581,7 @@ th {
 					<tr>
 						<th><spring:message code="radiology.studyResults" /></th>
 						<%--<td><a href="/openmrs/moduleServlet/radiology/viewer.jnlp?studyUID=${studyUID}"><spring:message code="general.download" /></a></td>--%>
-						<td><a href="${oviyamLink}" target="_tab">View Study</a></td>
+						<td><a href="${dicomViewerUrl}" target="_tab">View Study</a></td>
 					</tr>
 				</c:if>
 				<c:if test="${obs.creator != null}">

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyObsFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyObsFormControllerTest.java
@@ -154,29 +154,28 @@ public class RadiologyObsFormControllerTest extends BaseContextMockTest {
 	 * @see RadiologyObsFormController#getObs(Integer, Integer)
 	 */
 	@Test
-	@Verifies(value = "should populate model and view with oviyamlink for completed study and obs for given obs and given valid order", method = "getObs(Integer, Integer)")
-	public void getObs_ShouldPopulateModelAndViewWithOviyamLinkForCompletedStudyAndObsForGivenObsAndGivenValidOrder()
+	@Verifies(value = "should populate model and view with dicom viewer url for completed study and obs for given obs and given valid order", method = "getObs(Integer, Integer)")
+	public void getObs_ShouldPopulateModelAndViewWitDicomViewerUrlForCompletedStudyAndObsForGivenObsAndGivenValidOrder()
 	        throws Exception {
 		
 		mockStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
 		
 		when(Utils.serversAddress()).thenReturn("localhost");
 		when(Utils.serversPort()).thenReturn("8081");
-		when(Utils.viewerURLPath()).thenReturn("/oviyam2/viewer.html?");
-		when(Utils.oviyamLocalServerName()).thenReturn("oviyamlocal");
+		when(Utils.dicomViewerUrlBase()).thenReturn("/weasis/viewer?");
 		
 		ModelAndView modelAndView = radiologyObsFormController.getObs(validorderId, validObsIdForOrder20);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyObsForm"));
 		
-		assertTrue(modelAndView.getModelMap().containsKey("oviyamLink"));
-		String oviyamLink = (String) modelAndView.getModelMap().get("oviyamLink");
-		assertNotNull(oviyamLink);
+		assertTrue(modelAndView.getModelMap().containsKey("dicomViewerUrl"));
+		String dicomViewerUrl = (String) modelAndView.getModelMap().get("dicomViewerUrl");
+		assertNotNull(dicomViewerUrl);
 		
 		String patID = mockOrder.getPatient().getPatientIdentifier().getIdentifier();
-		assertTrue(oviyamLink.equals("http://localhost:8081/oviyam2/viewer.html?serverName=oviyamlocal&studyUID="
-		        + mockStudy.getStudyInstanceUid() + "&patientID=" + patID));
+		assertThat(dicomViewerUrl, is("http://localhost:8081/weasis/viewer?studyUID=" + mockStudy.getStudyInstanceUid()
+		        + "&patientID=" + patID));
 	}
 	
 	/**


### PR DESCRIPTION
* name global properties and Utils methods used to generate the dicom viewer
  url more specific but also general hence "dicomViewerUrlBase", "dicomViewerLocalServerName"
  without mentioning oviyam
* move dicom viewer url generation to Utils to reduce duplication in
  controllers
* update global properties defaults to weasis and update descriptions

see https://issues.openmrs.org/browse/RAD-41