### PR TITLE
RAD-82 Add class RadiologyOrder

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
@@ -1,0 +1,19 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology;
+
+import org.openmrs.TestOrder;
+
+/**
+ * RadiologyOrder represents a radiology examination
+ */
+public class RadiologyOrder extends TestOrder {
+
+}

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
@@ -12,11 +12,12 @@ package org.openmrs.module.radiology;
 import java.util.List;
 
 import org.openmrs.Obs;
-import org.openmrs.Order;
+import org.openmrs.Patient;
 import org.openmrs.api.APIException;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.DicomUtils.OrderRequest;
 import org.openmrs.module.radiology.db.GenericDAO;
+import org.openmrs.module.radiology.db.RadiologyOrderDAO;
 import org.openmrs.module.radiology.db.StudyDAO;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +26,58 @@ public interface RadiologyService extends OpenmrsService {
 	
 	public void setGdao(GenericDAO dao);
 	
+	public void setRadiologyOrderDao(RadiologyOrderDAO radiologyOrderDao);
+	
 	public void setSdao(StudyDAO dao);
 	
 	public Object get(String query, boolean unique);
 	
-	public Study getStudy(Integer id);
+	/**
+	 * Save given <code>RadiologyOrder</code> to the database
+	 * 
+	 * @param radiologyOrder radiology order to be created or updated
+	 * @return RadiologyOrder who was created or updated
+	 * @throws IllegalArgumentException if radiologyOrder is null
+	 * @should create new radiology order from given radiology order object
+	 * @should throw illegal argument exception given null
+	 */
+	public RadiologyOrder saveRadiologyOrder(RadiologyOrder radiologyOrder) throws IllegalArgumentException;
+	
+	/**
+	 * Get RadiologyOrder by its orderId
+	 * 
+	 * @param orderId of wanted RadiologyOrder
+	 * @return RadiologyOrder matching given orderId
+	 * @throws IllegalArgumentException if order id is null
+	 * @should return radiology order matching order id
+	 * @should return null if no match was found
+	 * @should throw illegal argument exception given null
+	 */
+	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) throws IllegalArgumentException;
+	
+	/**
+	 * Get RadiologyOrder's by its associated Patient
+	 * 
+	 * @param patient patient of wanted RadiologyOrders
+	 * @return RadiologyOrders associated with given patient
+	 * @throws IllegalArgumentException if patient is null
+	 * @should return all radiology orders associated with given patient
+	 * @should return empty list given patient without associated radiology orders
+	 * @should throw illegal argument exception given null
+	 */
+	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) throws IllegalArgumentException;
+	
+	/**
+	 * Get RadiologyOrder's by its associated Patients
+	 * 
+	 * @param patients list of patients for which RadiologyOrders are queried
+	 * @return RadiologyOrders associated with given patients
+	 * @throws IllegalArgumentException if patients is null
+	 * @should return all radiology orders associated with given patients
+	 * @should return all radiology orders given empty patient list
+	 * @should throw illegal argument exception given null
+	 */
+	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) throws IllegalArgumentException;
 	
 	/**
 	 * <p>
@@ -51,6 +99,8 @@ public interface RadiologyService extends OpenmrsService {
 	
 	public void sendModalityWorklist(Study s, OrderRequest orderRequest);
 	
+	public Study getStudy(Integer id);
+	
 	public Study getStudyByOrderId(Integer id);
 	
 	/**
@@ -65,17 +115,17 @@ public interface RadiologyService extends OpenmrsService {
 	public Study getStudyByStudyInstanceUid(String studyInstanceUid) throws IllegalArgumentException;
 	
 	/**
-	 * Get all studies corresponding to list of orders
+	 * Get all studies corresponding to list of RadiologyOrder's
 	 * 
-	 * @param orders orders for which studies will be returned
-	 * @return studies corresponding to given orders
+	 * @param radiologyOrders radiology orders for which studies will be returned
+	 * @return studies corresponding to given radiology orders
 	 * @throws IllegalArgumentException
-	 * @should fetch all studies for given orders
-	 * @should return empty list given orders without associated studies
-	 * @should return empty list given empty order list
+	 * @should fetch all studies for given radiology orders
+	 * @should return empty list given radiology orders without associated studies
+	 * @should return empty list given empty radiology order list
 	 * @should throw IllegalArgumentException given null
 	 */
-	public List<Study> getStudiesByOrders(List<Order> orders) throws IllegalArgumentException;
+	public List<Study> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) throws IllegalArgumentException;
 	
 	public GenericDAO db();
 	

--- a/api/src/main/java/org/openmrs/module/radiology/db/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/db/RadiologyOrderDAO.java
@@ -1,0 +1,44 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.db;
+
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.module.radiology.RadiologyOrder;
+
+/**
+ * RadiologyOrder-related database functions
+ * 
+ * @see org.openmrs.module.radiology.RadiologyService
+ */
+public interface RadiologyOrderDAO {
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#saveRadiologyOrder(RadiologyOrder)
+	 */
+	public RadiologyOrder saveRadiologyOrder(RadiologyOrder radiologyOrder);
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrderByOrderId(Integer)
+	 */
+	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId);
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrdersByPatient(Patient)
+	 */
+	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient);
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrdersByPatients(List<Patient>)
+	 */
+	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients);
+	
+}

--- a/api/src/main/java/org/openmrs/module/radiology/db/StudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/db/StudyDAO.java
@@ -12,7 +12,7 @@ package org.openmrs.module.radiology.db;
 import java.util.List;
 
 import org.openmrs.Obs;
-import org.openmrs.Order;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.Study;
 
 /**
@@ -21,8 +21,6 @@ import org.openmrs.module.radiology.Study;
  */
 public interface StudyDAO {
 	
-	public Study getStudy(Integer id);
-	
 	/**
 	 * Save the given <code>Study</code> to the database
 	 * 
@@ -30,6 +28,8 @@ public interface StudyDAO {
 	 * @return study who was created or updated
 	 */
 	public Study saveStudy(Study study);
+	
+	public Study getStudy(Integer id);
 	
 	/**
 	 * @param orderId
@@ -44,10 +44,10 @@ public interface StudyDAO {
 	public Study getStudyByStudyInstanceUid(String studyInstanceUid);
 	
 	/**
-	 * @param orders
-	 * @return studies for given orders
+	 * @param radiologyOrders
+	 * @return studies for given radiology orders
 	 */
-	public List<Study> getStudiesByOrders(List<Order> orders);
+	public List<Study> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders);
 	
 	/**
 	 * @param orderId

--- a/api/src/main/java/org/openmrs/module/radiology/db/hibernate/RadiologyOrderDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/db/hibernate/RadiologyOrderDAOImpl.java
@@ -1,0 +1,117 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.db.hibernate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Criteria;
+import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Restrictions;
+import org.openmrs.Patient;
+import org.openmrs.module.radiology.RadiologyOrder;
+import org.openmrs.module.radiology.db.RadiologyOrderDAO;
+
+/**
+ * Hibernate specific RadiologyOrder related functions. This class should not be used directly. All
+ * calls should go through the {@link org.openmrs.module.radiology.RadiologyService} methods.
+ *
+ * @see org.openmrs.module.radiology.db.RadiologyOrderDAO
+ * @see org.openmrs.module.radiology.RadiologyService
+ */
+public class RadiologyOrderDAOImpl implements RadiologyOrderDAO {
+	
+	private SessionFactory sessionFactory;
+	
+	/**
+	 * Set session factory that allows us to connect to the database that Hibernate knows about.
+	 *
+	 * @param sessionFactory
+	 */
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#saveRadiologyOrder(RadiologyOrder)
+	 */
+	@Override
+	public RadiologyOrder saveRadiologyOrder(RadiologyOrder radiologyOrder) {
+		sessionFactory.getCurrentSession().saveOrUpdate(radiologyOrder);
+		return radiologyOrder;
+	}
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrderByOrderId(Integer)
+	 */
+	@Override
+	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+		return (RadiologyOrder) sessionFactory.getCurrentSession().get(RadiologyOrder.class, orderId);
+	}
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrdersByPatient(Patient)
+	 */
+	@Override
+	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
+		List<RadiologyOrder> result = new ArrayList<RadiologyOrder>();
+		
+		Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
+		addRestrictionOnPatient(radiologyOrderCriteria, patient);
+		
+		result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+		return result;
+	}
+	
+	/**
+	 * A utility method creating a criteria for RadiologyOrder
+	 *
+	 * @return criteria for RadiologyOrder
+	 */
+	private Criteria createRadiologyOrderCriteria() {
+		return sessionFactory.getCurrentSession().createCriteria(RadiologyOrder.class);
+	}
+	
+	/**
+	 * Adds an equality restriction for given patient on given criteria if patient is not null
+	 *
+	 * @param criteria criteria on which equality restriction is set if patient is not null
+	 * @param patient patient for which equality restriction will be set
+	 */
+	private void addRestrictionOnPatient(Criteria criteria, Patient patient) {
+		if (patient != null)
+			criteria.add(Restrictions.eq("patient", patient));
+	}
+	
+	/**
+	 * @see org.openmrs.module.radiology.RadiologyService#getRadiologyOrdersByPatients(List<Patient>)
+	 */
+	@Override
+	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
+		List<RadiologyOrder> result = new ArrayList<RadiologyOrder>();
+		
+		Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
+		addRestrictionOnPatients(radiologyOrderCriteria, patients);
+		
+		result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+		return result;
+	}
+	
+	/**
+	 * Adds an in restriction for given patients on given criteria if patients is not empty
+	 *
+	 * @param criteria criteria on which in restriction is set if patients is not empty
+	 * @param patients patient list for which in restriction will be set
+	 */
+	private void addRestrictionOnPatients(Criteria criteria, List<Patient> patients) {
+		if (patients.size() > 0)
+			criteria.add(Restrictions.in("patient", patients));
+	}
+}

--- a/api/src/main/java/org/openmrs/module/radiology/db/hibernate/StudyDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/db/hibernate/StudyDAOImpl.java
@@ -16,6 +16,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.Obs;
 import org.openmrs.Order;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.db.StudyDAO;
 
@@ -63,14 +64,14 @@ public class StudyDAOImpl implements StudyDAO {
 	}
 	
 	/**
-	 * @see StudyDAO#getStudiesByOrders(List<Order>)
+	 * @see StudyDAO#getStudiesByRadiologyOrders(List<RadiologyOrder>)
 	 */
 	@Override
-	public List<Study> getStudiesByOrders(List<Order> orders) {
+	public List<Study> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
 		String query = "select study from Study as study where study.orderId in (:orderIds)";
 		
 		List<Integer> orderIds = new ArrayList<Integer>();
-		for (Order order : orders) {
+		for (Order order : radiologyOrders) {
 			orderIds.add(order.getOrderId());
 		}
 		

--- a/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
@@ -20,17 +20,20 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.Order;
+import org.openmrs.Patient;
 import org.openmrs.User;
 import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.DicomUtils;
 import org.openmrs.module.radiology.DicomUtils.OrderRequest;
 import org.openmrs.module.radiology.MwlStatus;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.ScheduledProcedureStepStatus;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.db.GenericDAO;
+import org.openmrs.module.radiology.db.RadiologyOrderDAO;
 import org.openmrs.module.radiology.db.StudyDAO;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,25 +41,72 @@ public class RadiologyServiceImpl extends BaseOpenmrsService implements Radiolog
 	
 	private GenericDAO gdao;
 	
+	private RadiologyOrderDAO radiologyOrderDAO;
+	
 	private StudyDAO sdao;
 	
 	private static final Log log = LogFactory.getLog(RadiologyServiceImpl.class);
+	
+	@Override
+	public void setRadiologyOrderDao(RadiologyOrderDAO radiologyOrderDAO) {
+		this.radiologyOrderDAO = radiologyOrderDAO;
+	}
 	
 	@Override
 	public void setSdao(StudyDAO dao) {
 		this.sdao = dao;
 	}
 	
-	@Transactional(readOnly = true)
+	/**
+	 * @see RadiologyService#saveRadiologyOrder(RadiologyOrder)
+	 */
+	@Transactional
 	@Override
-	public Study getStudy(Integer id) {
-		return sdao.getStudy(id);
+	public RadiologyOrder saveRadiologyOrder(RadiologyOrder radiologyOrder) {
+		if (radiologyOrder == null) {
+			throw new IllegalArgumentException("radiologyOrder is required");
+		}
+		
+		return radiologyOrderDAO.saveRadiologyOrder(radiologyOrder);
 	}
 	
+	/**
+	 * @see RadiologyService#getRadiologyOrderByOrderId(Integer)
+	 */
 	@Transactional(readOnly = true)
 	@Override
-	public Study getStudyByOrderId(Integer id) {
-		return sdao.getStudyByOrderId(id);
+	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+		if (orderId == null) {
+			throw new IllegalArgumentException("orderId is required");
+		}
+		
+		return radiologyOrderDAO.getRadiologyOrderByOrderId(orderId);
+	}
+	
+	/**
+	 * @see RadiologyService#getRadiologyOrdersByPatient(Patient)
+	 */
+	@Transactional(readOnly = true)
+	@Override
+	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
+		if (patient == null) {
+			throw new IllegalArgumentException("patient is required");
+		}
+		
+		return radiologyOrderDAO.getRadiologyOrdersByPatient(patient);
+	}
+	
+	/**
+	 * @see RadiologyService#getRadiologyOrdersByPatients(List<Patient>)
+	 */
+	@Transactional(readOnly = true)
+	@Override
+	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
+		if (patients == null) {
+			throw new IllegalArgumentException("patients is required");
+		}
+		
+		return radiologyOrderDAO.getRadiologyOrdersByPatients(patients);
 	}
 	
 	/**
@@ -182,6 +232,18 @@ public class RadiologyServiceImpl extends BaseOpenmrsService implements Radiolog
 		saveStudy(s);
 	}
 	
+	@Transactional(readOnly = true)
+	@Override
+	public Study getStudy(Integer id) {
+		return sdao.getStudy(id);
+	}
+	
+	@Transactional(readOnly = true)
+	@Override
+	public Study getStudyByOrderId(Integer id) {
+		return sdao.getStudyByOrderId(id);
+	}
+	
 	@Override
 	public void setGdao(GenericDAO dao) {
 		this.gdao = dao;
@@ -210,16 +272,16 @@ public class RadiologyServiceImpl extends BaseOpenmrsService implements Radiolog
 	}
 	
 	/**
-	 * @see RadiologyService#getStudiesByOrders(List<Order>)
+	 * @see RadiologyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<Study> getStudiesByOrders(List<Order> orders) {
-		if (orders == null) {
-			throw new IllegalArgumentException("orders are required");
+	public List<Study> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
+		if (radiologyOrders == null) {
+			throw new IllegalArgumentException("radiologyOrders are required");
 		}
 		
-		List<Study> result = sdao.getStudiesByOrders(orders);
+		List<Study> result = sdao.getStudiesByRadiologyOrders(radiologyOrders);
 		return result;
 	}
 	

--- a/api/src/main/resources/RadiologyOrder.hbm.xml
+++ b/api/src/main/resources/RadiologyOrder.hbm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.radiology">
+
+	<joined-subclass name="org.openmrs.module.radiology.RadiologyOrder"
+		extends="org.openmrs.TestOrder" table="radiology_order" lazy="false">
+		<key column="order_id" not-null="true" on-delete="cascade" />
+	</joined-subclass>
+
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -146,4 +146,23 @@
 			<column name="uuid" value="dbdb9a9b-56ea-11e5-a47f-08002719a237" />
 		</insert>
 	</changeSet>
+	<changeSet id="radiology-16" author="teleivo">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="radiology_order" />
+			</not>
+		</preConditions>
+		<comment>Create radiology_order table for new class RadiologyOrder</comment>
+		<createTable tableName="radiology_order">
+			<column name="order_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+		</createTable>
+		<addForeignKeyConstraint constraintName="radiology_order_order_id_fk"
+			baseTableName="radiology_order" baseColumnNames="order_id"
+			referencedTableName="test_order" referencedColumnNames="order_id" />
+		<addForeignKeyConstraint constraintName="radiology_study_order_id_fk"
+			baseTableName="radiology_study" baseColumnNames="order_id"
+			referencedTableName="radiology_order" referencedColumnNames="order_id" />
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -29,7 +29,14 @@
 						</property>
 					</bean>
 				</property>
-
+				<property name="radiologyOrderDao">
+					<bean
+						class="org.openmrs.module.radiology.db.hibernate.RadiologyOrderDAOImpl">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
 				<property name="sdao">
 					<bean class="org.openmrs.module.radiology.db.hibernate.StudyDAOImpl">
 						<property name="sessionFactory">

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceTestDataSet.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceTestDataSet.xml
@@ -20,7 +20,7 @@
   <concept_name concept_id="178" name="FRACTURE" locale="en" creator="1" date_created="2004-01-01 00:00:00" concept_name_id="178" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="15736c16-df81-11e4-98ec-08002798a7ad"/>
   
   <!-- radiology order type -->
-  <order_type order_type_id="5" name="Radiology" description="Order for radiology procedures" creator="1" date_created="2015-04-10 13:03:45" retired="0" uuid="e0daf799-a151-47bb-a430-1931d526d1fe"/>
+  <order_type order_type_id="5" name="Radiology Order" description="Order type for radiology exams" creator="1" date_created="2015-09-09" retired="0" uuid="dbdb9a9b-56ea-11e5-a47f-08002719a237"/>
   
   <!-- define metadata for the radiology service -->
   <global_property property="radiology.applicationUID" property_value="1.2.826.0.1.3680043.8.2186" description="You need a application root UID, this will be the prefix of any module DICOM object, the default value serves for debugging purposes" uuid="5d3962e1-eb27-49de-921b-01213ede5c73"/>
@@ -48,10 +48,14 @@
   <person_name person_name_id="2" preferred="true" person_id="70021" given_name="John" middle_name="Francis" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="0f1f7d08-076b-4fc6-acac-4bb91515141e"/>
   
   <!-- radiology orders with study -->
-  <orders order_id="2001" order_type_id="5"  urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" start_date="2015-02-04 14:35:00.0" auto_expire_date="2015-02-17 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" />
+  <orders order_id="2001" order_type_id="2" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" start_date="2015-02-04 14:35:00.0" auto_expire_date="2015-02-17 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" />
+  <test_order order_id="2001"/>
+  <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" priority="ROUTINE" modality="CT" mwl_status="DEFAULT"/>
 
-  <orders order_id="2002" order_type_id="5"   urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" start_date="2015-02-06 00:00:00.0" auto_expire_date="2015-02-14 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-05 12:24:10.0" voided="false" patient_id="70021" />
+  <orders order_id="2002" order_type_id="2" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" start_date="2015-02-06 00:00:00.0" auto_expire_date="2015-02-14 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-05 12:24:10.0" voided="false" patient_id="70021" />
+  <test_order order_id="2002"/>
+  <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" priority="ROUTINE" modality="MR" mwl_status="DEFAULT"/>
 
   <obs obs_id="20021" person_id="70021" order_id="2002" concept_id="178" obs_datetime="2015-02-06 17:14:00.0" location_id="1" creator="1" date_created="2015-02-06 17:14:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="RAD2002"/>
@@ -63,6 +67,8 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
   
   <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_type_id="5" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" start_date="2015-02-06 00:00:00.0" auto_expire_date="2015-02-14 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-05 12:24:10.0" voided="false" patient_id="70022" />
+  <orders order_id="2004" order_type_id="2" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" start_date="2015-02-06 00:00:00.0" auto_expire_date="2015-02-14 00:00:00.0" discontinued="false" creator="1" date_created="2015-02-05 12:24:10.0" voided="false" patient_id="70022" />
+  <test_order order_id="2004"/>
+  <radiology_order order_id="2004" />
   
 </dataset>

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -5,6 +5,7 @@
 
 <hibernate-configuration>
 	<session-factory>
+		<mapping resource="RadiologyOrder.hbm.xml" />
 		<mapping resource="RadiologyStudy.hbm.xml" />
 	</session-factory>
 </hibernate-configuration>

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardController.java
@@ -9,17 +9,14 @@
  */
 package org.openmrs.module.radiology.web.controller;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.Order;
 import org.openmrs.Patient;
-import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.radiology.RadiologyProperties;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.web.util.StudyStatusColumnGenerator;
@@ -37,9 +34,6 @@ public class RadiologyDashboardController {
 	@Autowired
 	RadiologyService radiologyService;
 	
-	@Autowired
-	OrderService orderService;
-	
 	/**
 	 * Get all orders for given patient criteria
 	 * 
@@ -53,10 +47,9 @@ public class RadiologyDashboardController {
 		
 		ModelAndView mav = new ModelAndView("/module/radiology/portlets/RadiologyDashboardTab");
 		
-		List<Order> matchedOrders = orderService.getOrders(Order.class, Arrays.asList(patient), null, null, null, null,
-		    Arrays.asList(RadiologyProperties.getRadiologyTestOrderType()));
+		List<RadiologyOrder> matchedOrders = radiologyService.getRadiologyOrdersByPatient(patient);
 		// TODO Status filter
-		List<Study> studies = radiologyService.getStudiesByOrders(matchedOrders);
+		List<Study> studies = radiologyService.getStudiesByRadiologyOrders(matchedOrders);
 		List<String> statuses = new Vector<String>();
 		List<String> priorities = new Vector<String>();
 		List<String> schedulers = new Vector<String>();
@@ -79,7 +72,7 @@ public class RadiologyDashboardController {
 		// TODO optimize all the function, get orders and studies(priorities, statuses, etc) in a row				
 		// Response variables
 		
-		mav.addObject(matchedOrders);
+		mav.addObject("orderList", matchedOrders);
 		mav.addObject("statuses", statuses);
 		mav.addObject("priorities", priorities);
 		mav.addObject("schedulers", schedulers);

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
@@ -35,6 +35,7 @@ import org.openmrs.module.radiology.DicomUtils.OrderRequest;
 import org.openmrs.module.radiology.Modality;
 import org.openmrs.module.radiology.MwlStatus;
 import org.openmrs.module.radiology.PerformedProcedureStepStatus;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.RequestedProcedurePriority;
@@ -98,7 +99,7 @@ public class RadiologyOrderFormController {
 		
 		if (Context.isAuthenticated()) {
 			Study study = new Study();
-			Order order = new Order();
+			RadiologyOrder order = new RadiologyOrder();
 			
 			User user = Context.getAuthenticatedUser();
 			if (user.hasRole(REFERRRING_PHYSICIAN, true) && order.getOrderer() == null) {
@@ -153,7 +154,7 @@ public class RadiologyOrderFormController {
 		
 		if (Context.isAuthenticated()) {
 			Study study = radiologyService.getStudyByOrderId(orderId);
-			Order order = orderService.getOrder(orderId);
+			RadiologyOrder order = radiologyService.getRadiologyOrderByOrderId(orderId);
 			modelAndView.addObject("order", order);
 			modelAndView.addObject("study", study);
 		}
@@ -185,7 +186,7 @@ public class RadiologyOrderFormController {
 	@RequestMapping(value = "/module/radiology/radiologyOrder.form", method = RequestMethod.POST, params = "saveOrder")
 	protected ModelAndView postSaveOrder(HttpServletRequest request,
 	        @RequestParam(value = "patient_id", required = false) Integer patientId, @ModelAttribute("study") Study study,
-	        BindingResult sErrors, @ModelAttribute("order") Order order, BindingResult oErrors) throws Exception {
+	        BindingResult sErrors, @ModelAttribute("order") RadiologyOrder order, BindingResult oErrors) throws Exception {
 		ModelAndView modelAndView = new ModelAndView("module/radiology/radiologyOrderForm");
 		
 		order.setOrderType(RadiologyProperties.getRadiologyTestOrderType());
@@ -205,7 +206,7 @@ public class RadiologyOrderFormController {
 			}
 			
 			try {
-				orderService.saveOrder(order);
+				radiologyService.saveRadiologyOrder(order);
 				study.setOrderId(order.getOrderId());
 				Study savedStudy = radiologyService.saveStudy(study);
 				
@@ -376,7 +377,7 @@ public class RadiologyOrderFormController {
 		
 		try {
 			if (request.getParameter("voidOrder") != null) {
-				Order o = orderService.getOrder(order.getOrderId());
+				Order o = radiologyService.getRadiologyOrderByOrderId(order.getOrderId());
 				radiologyService.sendModalityWorklist(radiologyService.getStudyByOrderId(o.getOrderId()),
 				    OrderRequest.Void_Order);
 				if (radiologyService.getStudyByOrderId(o.getOrderId()).getMwlStatus() == MwlStatus.VOID_OK) {
@@ -386,7 +387,7 @@ public class RadiologyOrderFormController {
 					request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.failWorklist");
 				}
 			} else if (request.getParameter("unvoidOrder") != null) {
-				Order o = orderService.getOrder(order.getOrderId());
+				Order o = radiologyService.getRadiologyOrderByOrderId(order.getOrderId());
 				radiologyService.sendModalityWorklist(radiologyService.getStudyByOrderId(o.getOrderId()),
 				    OrderRequest.Unvoid_Order);
 				if (radiologyService.getStudyByOrderId(o.getOrderId()).getMwlStatus() == MwlStatus.UNVOID_OK) {
@@ -396,7 +397,7 @@ public class RadiologyOrderFormController {
 					request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.failWorklist");
 				}
 			} else if (request.getParameter("discontinueOrder") != null) {
-				Order o = orderService.getOrder(order.getOrderId());
+				Order o = radiologyService.getRadiologyOrderByOrderId(order.getOrderId());
 				radiologyService.sendModalityWorklist(radiologyService.getStudyByOrderId(o.getOrderId()),
 				    OrderRequest.Discontinue_Order);
 				if (radiologyService.getStudyByOrderId(o.getOrderId()).getMwlStatus() == MwlStatus.DISCONTINUE_OK) {
@@ -406,7 +407,7 @@ public class RadiologyOrderFormController {
 					request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.failWorklist");
 				}
 			} else if (request.getParameter("undiscontinueOrder") != null) {
-				Order o = orderService.getOrder(order.getOrderId());
+				Order o = radiologyService.getRadiologyOrderByOrderId(order.getOrderId());
 				radiologyService.sendModalityWorklist(radiologyService.getStudyByOrderId(o.getOrderId()),
 				    OrderRequest.Undiscontinue_Order);
 				if (radiologyService.getStudyByOrderId(o.getOrderId()).getMwlStatus() == MwlStatus.UNDISCONTINUE_OK) {

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -147,7 +147,8 @@
 	</messages>
 	<!-- /Internationalization -->
 
-	<mappingFiles>RadiologyStudy.hbm.xml</mappingFiles>
+	<mappingFiles>RadiologyStudy.hbm.xml RadiologyOrder.hbm.xml
+	</mappingFiles>
 
 	<!-- Accessed through the url /pageContext()/moduleServlet/<moduleId>/<servlet-name> -->
 	<!-- <servlet> <servlet-name>viewer.jnlp</servlet-name> <servlet-class>org.weasis.servlet.Weasis_Launcher</servlet-class> 

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -25,7 +25,6 @@ import org.openmrs.EncounterProvider;
 import org.openmrs.EncounterType;
 import org.openmrs.Location;
 import org.openmrs.Obs;
-import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -35,6 +34,7 @@ import org.openmrs.PersonName;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.module.radiology.Modality;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RequestedProcedurePriority;
 import org.openmrs.module.radiology.Study;
 
@@ -126,41 +126,41 @@ public class RadiologyTestData {
 	}
 	
 	/**
-	 * Convenience method constructing a mock order for the tests
+	 * Convenience method constructing a mock RadiologyOrder for the tests
 	 */
-	public static Order getMockRadiologyOrder1() {
+	public static RadiologyOrder getMockRadiologyOrder1() {
 		
-		Order mockOrder = new Order();
-		mockOrder.setOrderId(1);
-		mockOrder.setOrderType(getMockRadiologyOrderType());
-		mockOrder.setPatient(getMockPatient1());
+		RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
+		mockRadiologyOrder.setOrderId(1);
+		mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
+		mockRadiologyOrder.setPatient(getMockPatient1());
 		Calendar cal = Calendar.getInstance();
 		cal.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
-		mockOrder.setStartDate(cal.getTime());
-		mockOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
-		mockOrder.setDiscontinued(false);
-		mockOrder.setVoided(false);
+		mockRadiologyOrder.setStartDate(cal.getTime());
+		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+		mockRadiologyOrder.setDiscontinued(false);
+		mockRadiologyOrder.setVoided(false);
 		
-		return mockOrder;
+		return mockRadiologyOrder;
 	}
 	
 	/**
-	 * Convenience method constructing a mock order for the tests
+	 * Convenience method constructing a mock RadiologyOrder for the tests
 	 */
-	public static Order getMockRadiologyOrder2() {
+	public static RadiologyOrder getMockRadiologyOrder2() {
 		
+		RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
+		mockRadiologyOrder.setOrderId(2);
+		mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
+		mockRadiologyOrder.setPatient(getMockPatient2());
 		Calendar cal = Calendar.getInstance();
-		Order mockOrder = new Order();
-		mockOrder.setOrderId(2);
-		mockOrder.setOrderType(getMockRadiologyOrderType());
-		mockOrder.setPatient(getMockPatient2());
 		cal.set(2015, Calendar.MARCH, 4, 14, 35, 0);
-		mockOrder.setStartDate(cal.getTime());
-		mockOrder.setInstructions("CT ABDOMEN PANCREAS WITHOUT IV CONTRAST");
-		mockOrder.setDiscontinued(true);
-		mockOrder.setVoided(false);
+		mockRadiologyOrder.setStartDate(cal.getTime());
+		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITHOUT IV CONTRAST");
+		mockRadiologyOrder.setDiscontinued(true);
+		mockRadiologyOrder.setVoided(false);
 		
-		return mockOrder;
+		return mockRadiologyOrder;
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/PortletsControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/PortletsControllerTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.when;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -27,13 +26,13 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.openmrs.Order;
-import org.openmrs.OrderType;
 import org.openmrs.Patient;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.Study;
@@ -50,7 +49,7 @@ import org.springframework.web.servlet.ModelAndView;
  * Tests {@link PortletsController}
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( { Context.class, RadiologyProperties.class })
+@PrepareForTest( { Context.class })
 @PowerMockIgnore( { "org.apache.commons.logging.*" })
 public class PortletsControllerTest {
 	
@@ -58,9 +57,7 @@ public class PortletsControllerTest {
 	
 	private List<Study> mockStudies;
 	
-	private List<Order> mockOrders;
-	
-	private OrderType mockRadiologyOrderType;
+	private List<RadiologyOrder> mockOrders;
 	
 	@Mock
 	private PatientService patientService;
@@ -90,9 +87,7 @@ public class PortletsControllerTest {
 		
 		String patientQuery = "";
 		
-		mockRadiologyOrderType = RadiologyTestData.getMockRadiologyOrderType();
-		
-		mockOrders = new ArrayList<Order>();
+		mockOrders = new ArrayList<RadiologyOrder>();
 		mockOrders.add(RadiologyTestData.getMockRadiologyOrder1());
 		mockOrders.add(RadiologyTestData.getMockRadiologyOrder2());
 		
@@ -106,13 +101,10 @@ public class PortletsControllerTest {
 		
 		when(Context.getDateFormat()).thenReturn(sdf);
 		when(Context.getOrderService()).thenReturn(orderService);
-		when(RadiologyProperties.getRadiologyTestOrderType()).thenReturn(RadiologyTestData.getMockRadiologyOrderType());
 		when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReferringPhysician());
-		when(radiologyService.getStudiesByOrders(mockOrders)).thenReturn(mockStudies);
+		when(radiologyService.getStudiesByRadiologyOrders(mockOrders)).thenReturn(mockStudies);
 		when(patientService.getPatients(patientQuery)).thenReturn(mockPatients);
-		when(
-		    (orderService.getOrders(Order.class, patientService.getPatients(patientQuery), null, null, null, null, Arrays
-		            .asList(mockRadiologyOrderType)))).thenReturn(mockOrders);
+		when(radiologyService.getRadiologyOrdersByPatients(patientService.getPatients(patientQuery))).thenReturn(mockOrders);
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyDashboardControllerTest.java
@@ -5,44 +5,30 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.openmrs.Order;
-import org.openmrs.OrderType;
 import org.openmrs.Patient;
 import org.openmrs.api.AdministrationService;
-import org.openmrs.api.OrderService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.radiology.RadiologyProperties;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.test.RadiologyTestData;
 import org.openmrs.test.BaseContextMockTest;
 import org.openmrs.test.Verifies;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Tests {@link RadiologyDashboardController}
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(RadiologyProperties.class)
-@PowerMockIgnore( { "org.apache.commons.logging.*" })
 public class RadiologyDashboardControllerTest extends BaseContextMockTest {
 	
-	private List<Order> mockOrders;
-	
-	private OrderType mockRadiologyOrderType;
+	private List<RadiologyOrder> mockOrders;
 	
 	private Patient mockPatient1;
 	
@@ -57,9 +43,6 @@ public class RadiologyDashboardControllerTest extends BaseContextMockTest {
 	private RadiologyService radiologyService;
 	
 	@Mock
-	private OrderService orderService;
-	
-	@Mock
 	private AdministrationService administrationService;
 	
 	@InjectMocks
@@ -67,30 +50,20 @@ public class RadiologyDashboardControllerTest extends BaseContextMockTest {
 	
 	@Before
 	public void runBeforeAllTests() {
-		PowerMockito.mockStatic(RadiologyProperties.class);
-		
 		mockPatient1 = RadiologyTestData.getMockPatient1();
 		invalidPatient = new Patient();
-		mockRadiologyOrderType = RadiologyTestData.getMockRadiologyOrderType();
-		mockOrders = new ArrayList<Order>();
+		mockOrders = new ArrayList<RadiologyOrder>();
 		mockOrders.add(RadiologyTestData.getMockRadiologyOrder1());
-		mockOrders.get(0).setOrderType(mockRadiologyOrderType);
 		
 		mockStudies = new ArrayList<Study>();
 		mockStudies.add(RadiologyTestData.getMockStudy1PostSave());
 		
-		ArrayList<Order> emptyOrdersList = new ArrayList<Order>();
+		ArrayList<RadiologyOrder> emptyOrdersList = new ArrayList<RadiologyOrder>();
 		
 		when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReferringPhysician());
-		when(RadiologyProperties.getRadiologyTestOrderType()).thenReturn(RadiologyTestData.getMockRadiologyOrderType());
-		
-		when(radiologyService.getStudiesByOrders(mockOrders)).thenReturn(mockStudies);
-		when(
-		    (orderService.getOrders(Order.class, Arrays.asList(mockPatient1), null, null, null, null, Arrays
-		            .asList(mockRadiologyOrderType)))).thenReturn(mockOrders);
-		when(
-		    (orderService.getOrders(Order.class, Arrays.asList(invalidPatient), null, null, null, null, Arrays
-		            .asList(mockRadiologyOrderType)))).thenReturn(emptyOrdersList);
+		when(radiologyService.getStudiesByRadiologyOrders(mockOrders)).thenReturn(mockStudies);
+		when((radiologyService.getRadiologyOrdersByPatient(mockPatient1))).thenReturn(mockOrders);
+		when((radiologyService.getRadiologyOrdersByPatient(invalidPatient))).thenReturn(emptyOrdersList);
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
@@ -31,6 +31,7 @@ import org.openmrs.api.OrderService;
 import org.openmrs.api.PatientService;
 import org.openmrs.module.radiology.MwlStatus;
 import org.openmrs.module.radiology.PerformedProcedureStepStatus;
+import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.RadiologyService;
 import org.openmrs.module.radiology.Study;
@@ -94,7 +95,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertNull(study.getStudyId());
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
 		assertNull(order.getOrderId());
 		
 		assertNull(order.getOrderer());
@@ -122,7 +123,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertNull(study.getStudyId());
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
 		assertNull(order.getOrderId());
 		
 		assertNotNull(order.getOrderer());
@@ -151,7 +152,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertNull(study.getStudyId());
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
 		assertNull(order.getOrderId());
 		
 		assertNotNull(order.getPatient());
@@ -188,7 +189,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertNull(study.getStudyId());
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
 		assertNull(order.getOrderId());
 		
 		assertNotNull(order.getOrderer());
@@ -213,7 +214,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertNull(study.getStudyId());
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
 		assertNull(order.getOrderId());
 		
 		assertNull(order.getPatient());
@@ -230,14 +231,14 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudy = RadiologyTestData.getMockStudy1PostSave();
 		
-		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
-		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudy);
+		when(radiologyService.getRadiologyOrderByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockRadiologyOrder);
+		when(radiologyService.getStudyByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockStudy);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingOrderByOrderId(mockOrder
-		        .getOrderId());
+		ModelAndView modelAndView = radiologyOrderFormController
+		        .getRadiologyOrderFormWithExistingOrderByOrderId(mockRadiologyOrder.getOrderId());
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
@@ -247,8 +248,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		assertThat(study, is(mockStudy));
 		
 		assertTrue(modelAndView.getModelMap().containsKey("order"));
-		Order order = (Order) modelAndView.getModelMap().get("order");
-		assertThat(order, is(mockOrder));
+		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap().get("order");
+		assertThat(order, is(mockRadiologyOrder));
 	}
 	
 	/**
@@ -261,12 +262,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
 		
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.saveRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		when(radiologyService.getStudy(mockStudyPostSave.getStudyId())).thenReturn(mockStudyPostSave);
 		
@@ -281,7 +282,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
 		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, null, mockStudyPreSave,
-		    studyErrors, mockOrder, orderErrors);
+		    studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.list"));
@@ -298,15 +299,14 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
 		
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.saveRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		when(radiologyService.getStudy(mockStudyPostSave.getStudyId())).thenReturn(mockStudyPostSave);
-		when(RadiologyProperties.getStudyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -318,12 +318,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockOrder.getPatient()
-		        .getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
 	}
 	
@@ -337,15 +337,14 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_ERR);
 		
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.saveRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		when(radiologyService.getStudy(mockStudyPostSave.getStudyId())).thenReturn(mockStudyPostSave);
-		when(RadiologyProperties.getStudyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -357,12 +356,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult studyErrors = mock(BindingResult.class);
 		when(studyErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockOrder.getPatient()
-		        .getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("radiology.savedFailWorklist"));
 		
 		mockRequest = new MockHttpServletRequest();
@@ -374,12 +373,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		mockStudyPostSave.setMwlStatus(MwlStatus.UPDATE_ERR);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		
-		modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockOrder.getPatient().getPatientId(),
-		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("radiology.savedFailWorklist"));
 	}
 	
@@ -393,17 +392,16 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		mockStudyPreSave.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
 		
 		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.saveRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		when(radiologyService.getStudy(mockStudyPostSave.getStudyId())).thenReturn(mockStudyPostSave);
-		when(RadiologyProperties.getStudyPrefix()).thenReturn(RadiologyTestData.getStudyPrefix());
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -415,8 +413,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockOrder.getPatient()
-		        .getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
@@ -432,13 +430,13 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	public void postSaveOrder_shouldNotRedirectIfOrderIsNotValidAccordingToOrderValidator() throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
 		
 		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
+		when(radiologyService.saveRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		when(radiologyService.getStudy(mockStudyPostSave.getStudyId())).thenReturn(mockStudyPostSave);
 		
@@ -452,8 +450,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(true);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockOrder.getPatient()
-		        .getPatientId(), mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.postSaveOrder(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("module/radiology/radiologyOrderForm"));
@@ -468,15 +466,13 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.VOID_OK);
 		
-		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
-		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(radiologyService.getRadiologyOrderByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockRadiologyOrder);
+		when(radiologyService.getStudyByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("voidOrder", "voidOrder");
@@ -488,12 +484,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockOrder.getPatient().getPatientId(),
-		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.voidedSuccessfully"));
 	}
 	
@@ -506,15 +502,13 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.UNVOID_OK);
 		
-		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
-		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(radiologyService.getRadiologyOrderByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockRadiologyOrder);
+		when(radiologyService.getStudyByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("unvoidOrder", "unvoidOrder");
@@ -526,12 +520,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockOrder.getPatient().getPatientId(),
-		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.unvoidedSuccessfully"));
 	}
 	
@@ -544,15 +538,13 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.DISCONTINUE_OK);
 		
-		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
-		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(radiologyService.getRadiologyOrderByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockRadiologyOrder);
+		when(radiologyService.getStudyByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("discontinueOrder", "discontinueOrder");
@@ -564,12 +556,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockOrder.getPatient().getPatientId(),
-		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.discontinuedSuccessfully"));
 	}
 	
@@ -582,15 +574,13 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 	        throws Exception {
 		
 		//given
-		Order mockOrder = RadiologyTestData.getMockRadiologyOrder1();
+		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
 		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		mockStudyPostSave.setMwlStatus(MwlStatus.UNDISCONTINUE_OK);
 		
-		when(orderService.getOrder(mockOrder.getOrderId())).thenReturn(mockOrder);
-		when(orderService.saveOrder(mockOrder)).thenReturn(mockOrder);
-		when(radiologyService.getStudyByOrderId(mockOrder.getOrderId())).thenReturn(mockStudyPostSave);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		when(radiologyService.getRadiologyOrderByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockRadiologyOrder);
+		when(radiologyService.getStudyByOrderId(mockRadiologyOrder.getOrderId())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("undiscontinueOrder", "undiscontinueOrder");
@@ -602,12 +592,12 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		BindingResult orderErrors = mock(BindingResult.class);
 		when(orderErrors.hasErrors()).thenReturn(false);
 		
-		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockOrder.getPatient().getPatientId(),
-		    mockStudyPreSave, studyErrors, mockOrder, orderErrors);
+		ModelAndView modelAndView = radiologyOrderFormController.post(mockRequest, mockRadiologyOrder.getPatient()
+		        .getPatientId(), mockStudyPreSave, studyErrors, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
 		assertThat(modelAndView.getViewName(), is("redirect:/patientDashboard.form?patientId="
-		        + mockOrder.getPatient().getPatientId()));
+		        + mockRadiologyOrder.getPatient().getPatientId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.undiscontinuedSuccessfully"));
 	}
 }


### PR DESCRIPTION
* add RadiologyOrder java class
* add hibernate mapping RadiologyOrder.hbm.xml
* add liquibase changeset to create table radiology_order
* adapt RadiologyServiceTestDataSet.xml
* add mapping resource to api/test-hibernate.cfg.xml
* add RadiologyOrder.hbm.xml mappingFile to config.xml
* add methods to RadiologyService
 - add saveRadiologyOrder(RadiologyOrder)
 - add getRadiologyOrderByOrderId(Integer)
 - add getRadiologyOrdersByPatient(Patient)
 - add getRadiologyOrdersByPatients(List<Patient>)
 - adapt getStudiesByOrders(List<Order>) ->
    getStudiesByRadiologyOrders(List<RadiologyOrder>)
* adapt controllers to use new RadiologyService methods and
  RadiologyOrder

see https://issues.openmrs.org/browse/RAD-82