### PR TITLE
RAD-96 Save study with RadiologyOrder

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
@@ -22,7 +22,18 @@ public class RadiologyOrder extends TestOrder {
 		return study;
 	}
 	
+	/**
+	 * Set the Order.study to the given Study. Keeps the bi-directional (one-to-one) association
+	 * between RadiologyOrder and Study in sync.
+	 *
+	 * @param study study which should be associated with this radiology order
+	 * @should set the study attribute to given study
+	 * @should set the radiology order of given study to this radiology order
+	 * @should not fail given null
+	 */
 	public void setStudy(Study study) {
+		if (study != null)
+			study.setRadiologyOrder(this);
 		this.study = study;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
@@ -16,7 +16,6 @@ import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
-import org.openmrs.api.APIException;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.api.OrderService;
@@ -37,15 +36,19 @@ public interface RadiologyService extends OpenmrsService {
 	public void setEncounterService(EncounterService encounterService);
 	
 	/**
-	 * Save given <code>RadiologyOrder</code> to the database
+	 * Save given <code>RadiologyOrder</code> and its <code>RadiologyOrder.study</code> to the
+	 * database
 	 * 
 	 * @param radiologyOrder radiology order to be created
 	 * @return RadiologyOrder who was created
 	 * @throws IllegalArgumentException if radiologyOrder is null
 	 * @throws IllegalArgumentException if radiologyOrder orderId is not null
-	 * @should create new radiology order from given radiology order object
+	 * @throws IllegalArgumentException if radiologyOrder.study is null
+	 * @should create new radiology order and study from given radiology order object
 	 * @should throw illegal argument exception given null
 	 * @should throw illegal argument exception given existing radiology order
+	 * @should throw illegal argument exception if given radiology order has no study
+	 * @should throw illegal argument exception if given study modality is null
 	 */
 	public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) throws IllegalArgumentException;
 	
@@ -105,25 +108,8 @@ public interface RadiologyService extends OpenmrsService {
 	
 	/**
 	 * <p>
-	 * Save the given <code>Study</code> to the database
-	 * </p>
-	 * Additionally, study and study.order information are written into a DICOM xml file.
-	 * 
-	 * @param study study to be created or updated
-	 * @return study who was created or updated
-	 * @throws IllegalArgumentException
-	 * @throws APIException
-	 * @should create new study from given study object
-	 * @should update existing study
-	 * @should throw IllegalArgumentException if study is null
-	 * @should throw APIException given study with empty order id
-	 * @should throw APIException given study with empty modality
-	 */
-	public Study saveStudy(Study study) throws APIException, IllegalArgumentException;
-	
-	/**
-	 * <p>
-	 * Update the performedStatus of the <code>Study</code> associated with studyInstanceUid in the database
+	 * Update the performedStatus of the <code>Study</code> associated with studyInstanceUid in the
+	 * database
 	 * </p>
 	 * 
 	 * @param studyInstanceUid study instance uid of study whos performedStatus should be updated

--- a/api/src/main/java/org/openmrs/module/radiology/Study.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Study.java
@@ -79,7 +79,7 @@ public class Study {
 		this.modality = modality;
 	}
 	
-	public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
+	void setRadiologyOrder(RadiologyOrder radiologyOrder) {
 		this.radiologyOrder = radiologyOrder;
 	}
 	

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyOrderTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyOrderTest.java
@@ -1,0 +1,63 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link RadiologyOrder}
+ */
+public class RadiologyOrderTest {
+	
+	/**
+	 * @see RadiologyOrder#setStudy(Study)
+	 * @verifies set the study attribute to given study
+	 */
+	@Test
+	public void setStudy_shouldSetTheStudyAttributeToGivenStudy() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		radiologyOrder.setStudy(study);
+		
+		assertThat(radiologyOrder.getStudy(), is(study));
+	}
+	
+	/**
+	 * @see RadiologyOrder#setStudy(Study)
+	 * @verifies set the radiology order of given study to this radiology order
+	 */
+	@Test
+	public void setStudy_shouldSetTheRadiologyOrderOfGivenStudyToThisRadiologyOrder() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		radiologyOrder.setStudy(study);
+		
+		assertThat(study.getRadiologyOrder(), is(radiologyOrder));
+	}
+	
+	/**
+	 * @see RadiologyOrder#setStudy(Study)
+	 * @verifies not fail given null
+	 */
+	@Test
+	public void setStudy_shouldNotFailGivenNull() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setStudy(null);
+		
+		assertNotNull(radiologyOrder);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/HL7GeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/HL7GeneratorTest.java
@@ -96,7 +96,6 @@ public class HL7GeneratorTest {
 		
 		study = new Study();
 		study.setStudyId(1);
-		study.setRadiologyOrder(radiologyOrder);
 		study.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
 		study.setModality(Modality.CT);
 		radiologyOrder.setStudy(study);

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01Test.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01Test.java
@@ -103,7 +103,6 @@ public class RadiologyORMO01Test {
 		
 		study = new Study();
 		study.setStudyId(1);
-		study.setRadiologyOrder(radiologyOrder);
 		study.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
 		study.setModality(Modality.CT);
 		radiologyOrder.setStudy(study);

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/segment/RadiologyOBRTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/segment/RadiologyOBRTest.java
@@ -58,7 +58,6 @@ public class RadiologyOBRTest {
 		Study study = new Study();
 		study.setStudyId(1);
 		study.setModality(Modality.CT);
-		study.setRadiologyOrder(radiologyOrder);
 		radiologyOrder.setStudy(study);
 		
 		ORM_O01 message = new ORM_O01();

--- a/api/src/test/java/org/openmrs/module/radiology/impl/RadiologyServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/impl/RadiologyServiceImplTest.java
@@ -1,0 +1,227 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.impl;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openmrs.Encounter;
+import org.openmrs.GlobalProperty;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.radiology.Modality;
+import org.openmrs.module.radiology.MwlStatus;
+import org.openmrs.module.radiology.RadiologyConstants;
+import org.openmrs.module.radiology.RadiologyOrder;
+import org.openmrs.module.radiology.RadiologyProperties;
+import org.openmrs.module.radiology.RadiologyService;
+import org.openmrs.module.radiology.ScheduledProcedureStepStatus;
+import org.openmrs.module.radiology.Study;
+import org.openmrs.module.radiology.db.StudyDAO;
+import org.openmrs.module.radiology.db.hibernate.StudyDAOImpl;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+/**
+ * Tests {@link RadiologyServiceImpl}
+ */
+public class RadiologyServiceImplTest extends BaseModuleContextSensitiveTest {
+	
+	private static final String STUDIES_TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyServiceTestDataSet.xml";
+	
+	private static final int PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER = 70011;
+	
+	private static final int RADIOLOGY_ORDER_ID_WITHOUT_STUDY = 2004;
+	
+	private static final int EXISTING_STUDY_ID = 1;
+	
+	private static final String MWL_DIRECTORY = "mwl";
+	
+	private PatientService patientService = null;
+	
+	private AdministrationService administrationService = null;
+	
+	private EncounterService encounterService = null;
+	
+	private ProviderService providerService = null;
+	
+	private OrderService orderService = null;
+	
+	private RadiologyServiceImpl radiologyServiceImpl = null;
+	
+	private RadiologyService radiologyService = null;
+	
+	private StudyDAO studyDAO = null;
+	
+	private Method saveRadiologyOrderEncounterMethod = null;
+	
+	private Method saveStudyMethod = null;
+	
+	@Rule
+	public TemporaryFolder temporaryBaseFolder = new TemporaryFolder();
+	
+	@Before
+	public void runBeforeAllTests() throws Exception {
+		
+		if (patientService == null) {
+			patientService = Context.getPatientService();
+		}
+		
+		if (administrationService == null) {
+			administrationService = Context.getAdministrationService();
+		}
+		
+		if (radiologyService == null) {
+			radiologyService = Context.getService(RadiologyService.class);
+		}
+		
+		if (providerService == null) {
+			providerService = Context.getProviderService();
+		}
+		
+		if (orderService == null) {
+			orderService = Context.getOrderService();
+		}
+		if (encounterService == null) {
+			encounterService = Context.getEncounterService();
+		}
+		
+		if (studyDAO == null) {
+			StudyDAOImpl studyDAOImpl = new StudyDAOImpl();
+			studyDAOImpl.setSessionFactory(Context.getRegisteredComponent("sessionFactory", SessionFactory.class));
+			studyDAO = studyDAOImpl;
+		}
+		
+		if (radiologyServiceImpl == null) {
+			radiologyServiceImpl = new RadiologyServiceImpl();
+			radiologyServiceImpl.setOrderService(orderService);
+			radiologyServiceImpl.setEncounterService(encounterService);
+			radiologyServiceImpl.setSdao(studyDAO);
+		}
+		
+		saveRadiologyOrderEncounterMethod = RadiologyServiceImpl.class.getDeclaredMethod("saveRadiologyOrderEncounter",
+		    new Class[] { org.openmrs.Patient.class, org.openmrs.Provider.class, java.util.Date.class });
+		saveRadiologyOrderEncounterMethod.setAccessible(true);
+		
+		saveStudyMethod = RadiologyServiceImpl.class.getDeclaredMethod("saveStudy",
+		    new Class[] { org.openmrs.module.radiology.Study.class });
+		saveStudyMethod.setAccessible(true);
+		
+		executeDataSet(STUDIES_TEST_DATASET);
+	}
+	
+	/**
+	 * @see RadiologyServiceImpl#saveRadiologyOrderEncounter(Patient,Provider,Date)
+	 * @verifies save radiology order encounter for given parameters
+	 */
+	@Test
+	public void saveRadiologyOrderEncounter_shouldSaveRadiologyOrderEncounterForGivenParameters() throws Exception {
+		
+		Patient patient = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
+		Provider provider = providerService.getProviderByIdentifier("1");
+		Date encounterDatetime = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
+		
+		Encounter encounter = (Encounter) saveRadiologyOrderEncounterMethod.invoke(radiologyServiceImpl, new Object[] {
+		        patient, provider, encounterDatetime });
+		
+		assertNotNull(encounter);
+		assertThat(encounter.getPatient(), is(patient));
+		assertThat(encounter.getProvidersByRole(RadiologyProperties.getOrderingProviderEncounterRole()).size(), is(1));
+		assertThat(encounter.getProvidersByRole(RadiologyProperties.getOrderingProviderEncounterRole()).contains(provider),
+		    is(true));
+		assertThat(encounter.getEncounterDatetime(), is(encounterDatetime));
+		assertThat(encounter.getEncounterType(), is(RadiologyProperties.getRadiologyEncounterType()));
+	}
+	
+	/**
+	 * @see RadiologyServiceImpl#saveStudy(Study)
+	 * @verifies create new study from given study object
+	 */
+	@Test
+	public void saveStudy_shouldCreateNewStudyFromGivenStudyObject() throws Exception {
+		
+		// Set temporary mwl folder, so that the DICOM MWL xml file created on saveStudy() will be removed after test finishes.
+		File temporaryMwlFolder = temporaryBaseFolder.newFolder(MWL_DIRECTORY);
+		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_MWL_DIR, temporaryMwlFolder
+		        .getAbsolutePath()));
+		
+		Study radiologyStudy = getUnsavedStudy();
+		RadiologyOrder radiologyOrder = radiologyService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
+		radiologyOrder.setStudy(radiologyStudy);
+		
+		Study createdStudy = (Study) saveStudyMethod.invoke(radiologyServiceImpl, new Object[] { radiologyStudy });
+		
+		assertNotNull(createdStudy);
+		assertThat(createdStudy, is(radiologyStudy));
+		assertThat(createdStudy.getStudyId(), is(radiologyStudy.getStudyId()));
+		assertNotNull(createdStudy.getStudyInstanceUid());
+		assertThat(createdStudy.getStudyInstanceUid(), is(RadiologyProperties.getStudyPrefix() + createdStudy.getStudyId()));
+		assertThat(createdStudy.getModality(), is(radiologyStudy.getModality()));
+		assertThat(createdStudy.getRadiologyOrder(), is(radiologyStudy.getRadiologyOrder()));
+	}
+	
+	/**
+	 * Convenience method to get a Study object with all required values filled (except
+	 * radiologyOrder) in but which is not yet saved in the database
+	 * 
+	 * @return Study object that can be saved to the database
+	 */
+	public Study getUnsavedStudy() {
+		
+		Study study = new Study();
+		study.setModality(Modality.CT);
+		study.setMwlStatus(MwlStatus.DEFAULT);
+		study.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+		return study;
+	}
+	
+	/**
+	 * @see RadiologyServiceImpl#saveStudy(Study)
+	 * @verifies update existing study
+	 */
+	@Test
+	public void saveStudy_shouldUpdateExistingStudy() throws Exception {
+		
+		// Set temporary mwl folder, so that the DICOM MWL xml file created on saveStudy() will be removed after test finishes.
+		File temporaryMwlFolder = temporaryBaseFolder.newFolder(MWL_DIRECTORY);
+		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_MWL_DIR, temporaryMwlFolder
+		        .getAbsolutePath()));
+		
+		Study existingStudy = radiologyServiceImpl.getStudy(EXISTING_STUDY_ID);
+		Modality modalityPreUpdate = existingStudy.getModality();
+		Modality modalityPostUpdate = Modality.XA;
+		existingStudy.setModality(modalityPostUpdate);
+		
+		Study updatedStudy = (Study) saveStudyMethod.invoke(radiologyServiceImpl, new Object[] { existingStudy });
+		
+		assertNotNull(updatedStudy);
+		assertThat(updatedStudy, is(existingStudy));
+		assertThat(modalityPreUpdate, is(not(modalityPostUpdate)));
+		assertThat(updatedStudy.getModality(), is(modalityPostUpdate));
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
@@ -176,11 +176,10 @@ public class RadiologyOrderFormController {
 			
 			try {
 				radiologyService.placeRadiologyOrder(radiologyOrder);
-				radiologyOrder.getStudy().setRadiologyOrder(radiologyOrder);
-				Study savedStudy = radiologyService.saveStudy(radiologyOrder.getStudy());
 				
 				radiologyService.sendModalityWorklist(radiologyOrder, OrderRequest.Save_Order);
-				if (savedStudy.getMwlStatus() == MwlStatus.SAVE_ERR || savedStudy.getMwlStatus() == MwlStatus.UPDATE_ERR) {
+				if (radiologyOrder.getStudy().getMwlStatus() == MwlStatus.SAVE_ERR
+				        || radiologyOrder.getStudy().getMwlStatus() == MwlStatus.UPDATE_ERR) {
 					request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.savedFailWorklist");
 				} else {
 					request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.saved");

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -76,7 +76,6 @@ public class RadiologyTestData {
 	public static Study getMockStudy2PreSave() {
 		
 		Study mockStudy = new Study();
-		mockStudy.setRadiologyOrder(getMockRadiologyOrder2());
 		mockStudy.setModality(Modality.CT);
 		
 		return mockStudy;
@@ -118,7 +117,7 @@ public class RadiologyTestData {
 		
 		EncounterProvider encounterProvider = new EncounterProvider();
 		encounterProvider.setId(1);
-		Set providerSet = new HashSet();
+		Set<EncounterProvider> providerSet = new HashSet<EncounterProvider>();
 		providerSet.add(encounterProvider);
 		mockEncounter.setEncounterProviders(providerSet);
 		

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
@@ -210,11 +210,9 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		//given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
-		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
+		mockRadiologyOrder.getStudy().setMwlStatus(MwlStatus.SAVE_OK);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		when(radiologyService.saveStudy(mockRadiologyOrder.getStudy())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -243,11 +241,9 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		//given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
-		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_OK);
+		mockRadiologyOrder.getStudy().setMwlStatus(MwlStatus.SAVE_OK);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		when(radiologyService.saveStudy(mockRadiologyOrder.getStudy())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -277,12 +273,9 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		//given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
-		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
-		mockStudyPostSave.setMwlStatus(MwlStatus.SAVE_ERR);
+		mockRadiologyOrder.getStudy().setMwlStatus(MwlStatus.SAVE_ERR);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		when(radiologyService.saveStudy(mockRadiologyOrder.getStudy())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -305,9 +298,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		mockSession = new MockHttpSession();
 		mockRequest.setSession(mockSession);
 		
-		mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
-		mockStudyPostSave.setMwlStatus(MwlStatus.UPDATE_ERR);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
+		mockRadiologyOrder.getStudy().setMwlStatus(MwlStatus.SAVE_ERR);
+		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		
 		modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest, mockRadiologyOrder.getPatient()
 		        .getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
@@ -329,14 +321,11 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		//given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		mockRadiologyOrder.setStudy(RadiologyTestData.getMockStudy1PostSave());
 		mockRadiologyOrder.getStudy().setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
 		
 		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		when(radiologyService.saveStudy(mockRadiologyOrder.getStudy())).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");
@@ -365,13 +354,10 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		//given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		Study mockStudyPreSave = RadiologyTestData.getMockStudy1PreSave();
-		Study mockStudyPostSave = RadiologyTestData.getMockStudy1PostSave();
 		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
 		
 		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		when(radiologyService.saveStudy(mockStudyPreSave)).thenReturn(mockStudyPostSave);
 		
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
 		mockRequest.addParameter("saveOrder", "saveOrder");


### PR DESCRIPTION
* remove saveStudy from api
* make saveStudy a private method in RadiologyServiecImpl
* move tests of private RadiologyServiceImpl methods to
  RadiologyServiceImplTest
* handle bi-directional associaton from RadiologyOrder to Study
  in RadiologyOrder.setStudy()
* adjust RadiologyOrderFormController to changes

see https://issues.openmrs.org/browse/RAD-96